### PR TITLE
Remove hardcoded .so

### DIFF
--- a/sql/format.sql
+++ b/sql/format.sql
@@ -3,5 +3,5 @@
 
 CREATE OR REPLACE FUNCTION format(string TEXT, h HSTORE)
   RETURNS TEXT AS
-'format_hstore.so', 'format_hstore'
+'format_hstore', 'format_hstore'
 LANGUAGE C IMMUTABLE STRICT;


### PR DESCRIPTION
This makes the extension usable on systems that don't use .so to indicate a shared library (.dll on Windows).